### PR TITLE
Silence MSVC warning C4389

### DIFF
--- a/4coder_fleury_command_server.cpp
+++ b/4coder_fleury_command_server.cpp
@@ -482,7 +482,8 @@ int sts_net_check_socket_set(sts_net_set_t* set, const float timeout) {
     struct timeval  tv;
     int             i, max_fd, result;
     
-    
+    #pragma warning( push )
+    #pragma warning( disable : 4389 )
     FD_ZERO(&fds);
     for (i = 0, max_fd = 0; i < STS_NET_SET_SOCKETS; ++i) {
         if (set->sockets[i]) {


### PR DESCRIPTION
"error C2220: the following warning is treated as an error
warning C4389: '==': signed/unsigned mismatch"
This prevents it from compiling